### PR TITLE
Update react dependencies to 15.x

### DIFF
--- a/js/Dial.js
+++ b/js/Dial.js
@@ -58,8 +58,8 @@ var Dial = React.createClass({
 
     var divStyles = {
       position: 'relative', // relative positioning to support absolutely positioned children
-      width: '' + this.props.width,
-      height: '' + this.props.width, // always square
+      width: this.props.width,
+      height: this.props.width, // always square
       display: 'flex' // allow for textbox to be easily centered
     };
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "homepage": "https://github.com/whmountains/react-dial#readme",
   "dependencies": {
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "react": ">=0.14.7",
+    "react-dom": ">=0.14.7"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dial",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "jquery-knob for react",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Latest react displays warnings when passed unitless string values to div style props.
This allows upgrading to react 15.x without npm installing version 0.14.7 under react-dial, and so causing multiple versions of react to be loaded.
